### PR TITLE
Initial Release Automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 coverage.txt
+dist/
 git2consul
 .idea
 *.swp

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,26 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+project_name: git2consul
+env:
+  - CGO_ENABLED=0
+before:
+  hooks:
+    - go mod tidy
+builds:
+- ldflags:
+  - -X {{.Env.VERSION_PKG}}.Branch={{.Env.BRANCH}}
+  - -X {{.Env.VERSION_PKG}}.BuildDate={{.Env.DATE}}
+  - -X {{.Env.VERSION_PKG}}.GitSHA1={{.Env.COMMIT}}
+archives:
+- replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  skip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,37 @@
 branches:
   only:
   - master
+  - /^v\d+\.\d+\.\d+$/
+sudo: required
 language: go
 matrix:
   include:
     - go: 1.13.x
+env:
+  matrix:
+  - GO_RELEASER_VERSION=v0.123.3
 
 before_install:
   - GO111MODULE=off go get golang.org/x/lint/golint
+  - curl -L -o /tmp/goreleaser.tar.gz https://github.com/goreleaser/goreleaser/releases/download/${GO_RELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz
+  - sudo tar -xzf /tmp/goreleaser.tar.gz -C /usr/local/bin/ && sudo chmod +x /usr/local/bin/goreleaser
 
 install:
   - # skip
 
 script:
   - make test-dirty
+  - make test-release
   - make test
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+
+# Calls goreleaser to build and push artifacts
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: make clean release
+  on:
+    tags: true
+    condition: $TRAVIS_OS_NAME = linux

--- a/README.md
+++ b/README.md
@@ -201,6 +201,19 @@ See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for details.
 $ make build
 ```
 
+### Releases
+This project is using [goreleaser](https://goreleaser.com). GitHub release creation is automated using Travis
+CI. New releases are automatically created when new tags are pushed to the repo.
+```
+$ TAG=v0.0.2 make tag
+```
+
+How to manually create a release without relying on Travis CI.
+```
+$ TAG=v0.0.2 make tag
+$ GITHUB_TOKEN=xxx make clean release
+```
+
 ## License
 
 See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Description

Use goreleaser and Travis CI to automatically build binaries and create
GitHub releases. GitHub releases are automatically created when new tags
are pushed to GitHub.

https://goreleaser.com

Fixes #20 

## Type of change

Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)
* This change requires a documentation update

## Environment

* Runtime version(Java, Go, Python, etc): n/a
