### PR TITLE
docs: Fix URL typo in README [Fixes #33]

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Sample config with ssh auth
   "repos": [
     {
       "name": "example",
-      "url": "http://github.com/DummyOrg/ExampleRepo.git",
+      "url": "ssh://github.com/DummyOrg/ExampleRepo.git",
       "credentials: {
             "private_key": {
                   "pk_key": "/path/to/priv_key",


### PR DESCRIPTION
<!--
    Please read https://github.com/KohlsTechnology/git2consul-go/blob/master/.github/PULL_REQUEST_TEMPLATE.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Fix for a small typo in the readme.

The ssh auth example is using an incorrect protocol in the url (`https://`), I've corrected it to `ssh://`

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #33

**Type of change**
<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] Unit tests updated
- [X] Documentation updated
