### PR TITLE
config: Add ability to configure Consul via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ git2consul will attempt to use sane defaults for configuration. However, since g
 | repos:hooks:type          | no       | polling        |  polling, webhook | Type of hook to use to fetch changes on the repository. See [below](#webhooks).
 | repos:hooks:interval      | no       | 60             | `int`                                      | Interval, in seconds, to poll if polling is enabled
 | repos:hooks:url           | no       | ??             | `string`                                   | ???
-| consul:address            | no       | 127.0.0.1:8500 | `string`                                   | Consul address to connect to. It can be either the IP or FQDN with port included
-| consul:ssl                | no       | false          | true, false                                | Whether to use HTTPS to communicate with Consul
-| consul:ssl_verify         | no       | false          | true, false                                | Whether to verify certificates when connecting via SSL
-| consul:token              | no       |                | `string`                                   | Consul API Token
+| consul:address            | no       | 127.0.0.1:8500 | `string`                                   | Consul address to connect to. It can be either the IP or FQDN with port included. Will use the `CONSUL_HTTP_ADDR` environment variable as a fallback if present. If `CONSUL_HTTP_ADDR` contains `https://`, consul:ssl is implied to be true.
+| consul:ssl                | no       | false          | true, false                                | Whether to use HTTPS to communicate with Consul. Will use the `CONSUL_HTTP_SSL` environment variable as a fallback if present.
+| consul:ssl_verify         | no       | false          | true, false                                | Whether to verify certificates when connecting via SSL. Will use the `CONSUL_HTTP_SSL_VERIFY` environment variable as a fallback if present.
+| consul:token              | no       |                | `string`                                   | Consul API Token. Will use the `CONSUL_HTTP_TOKEN` environment variable as a fallback if present.
 
 ### Webhooks
 

--- a/config/load.go
+++ b/config/load.go
@@ -122,13 +122,20 @@ func (c *Config) checkConfig() error {
 
 // Return Consul configuration from environment variables
 func (c *Config) setEnvConsulConfig() {
+	// log context
+	logger := log.WithFields(log.Fields{
+		"caller": "config",
+	})
+
 	// Use the value of CONSUL_HTTP_ADDR if not empty
 	if envAddr := os.Getenv(api.HTTPAddrEnvName); envAddr != "" {
 		c.Consul.Address = envAddr
+		logger.Infof("Consul address set by %s", api.HTTPAddrEnvName)
 
 		// Enable SSL if CONSUL_HTTP_ADDR contains 'https://'
 		if strings.Contains(strings.ToLower(envAddr), "https://") {
 			c.Consul.SSLEnable = true
+			logger.Infof("Consul SSL enabled as %s contains 'https://'", api.HTTPAddrEnvName)
 		}
 	}
 
@@ -136,6 +143,7 @@ func (c *Config) setEnvConsulConfig() {
 	if envSSL := os.Getenv(api.HTTPSSLEnvName); envSSL != "" {
 		if envSSLValue, err := strconv.ParseBool(envSSL); err == nil {
 			c.Consul.SSLEnable = envSSLValue
+			logger.Infof("Consul SSL enabled by %s", api.HTTPSSLEnvName)
 		}
 	}
 
@@ -143,12 +151,14 @@ func (c *Config) setEnvConsulConfig() {
 	if envSSLVerify := os.Getenv(api.HTTPSSLVerifyEnvName); envSSLVerify != "" {
 		if envSSLVerifyValue, err := strconv.ParseBool(envSSLVerify); err == nil {
 			c.Consul.SSLVerify = envSSLVerifyValue
+			logger.Infof("Consul SSL verification enabled by %s", api.HTTPSSLVerifyEnvName)
 		}
 	}
 
 	// Use the value of CONSUL_HTTP_TOKEN if not empty
 	if envToken := os.Getenv(api.HTTPTokenEnvName); envToken != "" {
 		c.Consul.Token = envToken
+		logger.Infof("Consul token set by %s", api.HTTPTokenEnvName)
 	}
 }
 

--- a/config/load.go
+++ b/config/load.go
@@ -127,7 +127,7 @@ func (c *Config) setEnvConsulConfig() {
 		c.Consul.Address = envAddr
 
 		// Enable SSL if CONSUL_HTTP_ADDR contains 'https://'
-		if strings.Contains(envAddr, "https://") {
+		if strings.Contains(strings.ToLower(envAddr), "https://") {
 			c.Consul.SSLEnable = true
 		}
 	}

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -42,4 +43,23 @@ func TestLoadInvalidConfig(t *testing.T) {
 
 	_, err := Load(file)
 	assert.Error(t, err)
+}
+
+func TestLoadConsulEnv(t *testing.T) {
+	file := filepath.Join("test-fixtures", "local.json")
+
+	os.Setenv("CONSUL_HTTP_ADDR", "127.0.0.1:8500")
+	defer os.Unsetenv("CONSUL_HTTP_ADDR")
+
+	os.Setenv("CONSUL_HTTP_SSL", "false")
+	defer os.Unsetenv("CONSUL_HTTP_SSL")
+
+	os.Setenv("CONSUL_HTTP_SSL_VERIFY", "false")
+	defer os.Unsetenv("CONSUL_HTTP_SSL_VERIFY")
+
+	os.Setenv("CONSUL_HTTP_TOKEN", "abcdefg123456789")
+	defer os.Unsetenv("CONSUL_HTTP_TOKEN")
+
+	_, err := Load(file)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION

<!--
    Please read https://github.com/KohlsTechnology/git2consul-go/blob/master/.github/PULL_REQUEST_TEMPLATE.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
git2consul can now read environment variables for configuring Consul. These same environment variables are already used by Consul for the purposes of configuration, so they have been included as a potential source of configuration here too.

The function that looks for Consul environment variables is called after the values from the JSON configuration file have been applied (but before the default values are set), so they will not overwrite any values present in said file.
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #43 

**Type of change**

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

**Checklist**

- [x] Unit tests updated
- [x] Documentation updated
