### PR TITLE
Fixed sort.Search() in webhook implementation to support multiple repos

### DIFF
--- a/watcher/webhook.go
+++ b/watcher/webhook.go
@@ -132,7 +132,7 @@ func (w *Watcher) githubHandler(rw http.ResponseWriter, rq *http.Request) {
 	branchName := ref[11:]
 
 	i := sort.Search(len(w.Repositories), func(i int) bool {
-		return w.Repositories[i].Name() == repository
+		return w.Repositories[i].Name() >= repository
 	})
 
 	// sort.Search could return last index if not found, so need to check once more


### PR DESCRIPTION
Webhook implementation did not allow for multiple repos

Updated the sort.Search() in webhook.go to ensure all repos can be found in the repositories list

* Bug fix (non-breaking change which fixes an issue)

**Checklist**

- No unit tests need updates
- No documentation needs updates
