### PR TITLE
chore: bump to Go 1.17.5

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.4, 1.16.11]
+        go-version: [1.17.5, 1.16.11]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -58,7 +58,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.4
+          go-version: 1.17.5
       - name: Prepare
         id: prep
         run: |


### PR DESCRIPTION
Dockerfile updates will be done on #81.