### PR TITLE
chore: bump Go version 1.17.8

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.6, 1.16.11]
+        go-version: [1.17.8, 1.16.11]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -58,7 +58,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.6
+          go-version: 1.17.8
       - name: Prepare
         id: prep
         run: |


### PR DESCRIPTION
Dockerfile changes will be made in #91.